### PR TITLE
LW-1139 Add environment variable for REST API base url.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # In CodePipeline, we won't have the client libraries. Assume the lambda layer has already been deployed
-if [ ${CI:=false} != true ]
+# Check if one of the required files exists. If it does, assume it's already been installed and skip this step.
+if [[ ${CI:=false} != true && (! -f './oracle-instant-client/lib/libociicus.so') ]]
 then
   ./oracle-install.sh || { echo "Failed to install oracle instant client."; exit 1; }
 fi

--- a/src/aleph-gateway-stack.ts
+++ b/src/aleph-gateway-stack.ts
@@ -26,6 +26,7 @@ export default class AlephGatewayStack extends cdk.Stack {
       SENTRY_ENVIRONMENT: props.stage,
       SENTRY_RELEASE: `${props.sentryProject}@${props.sentryVersion}`,
       ALEPH_URL: StringParameter.valueForStringParameter(this, `${paramStorePath}/aleph_url`),
+      ALEPH_REST_API_URL: StringParameter.valueForStringParameter(this, `${paramStorePath}/aleph_rest_api_url`),
       AUTHORIZED_CLIENTS: StringParameter.valueForStringParameter(this, `${paramStorePath}/authorized_clients`),
       DEFAULT_LIBRARY: 'ndu50',
     }


### PR DESCRIPTION
We still need the ALEPH_URL variable because there are other endpoints which still use this instead of the REST APIs.

Also skips oracle instant client install if it's already been completed. (Quicker deployment and avoids sudo.)